### PR TITLE
fix html linebreak issue

### DIFF
--- a/src/main/java/org/zanata/mt/util/ArticleUtil.java
+++ b/src/main/java/org/zanata/mt/util/ArticleUtil.java
@@ -10,10 +10,12 @@ import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.parser.Parser;
 import org.jsoup.parser.Tag;
+import org.jsoup.safety.Whitelist;
 import org.zanata.mt.model.TranslatableHTMLNode;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -122,9 +124,13 @@ public final class ArticleUtil {
      * IMPORTANT: This assumes the html is wrap in single html node
      */
     public static Element wrapHTML(String html) {
-        String wrapHTML = "<div id='" + getWrapperId() + "'>" + html + "</div>";
-        Document doc = Jsoup.parse(wrapHTML, "", Parser.xmlParser());
-        doc.outputSettings().indentAmount(0).prettyPrint(false);
+        String wrapHTML = html;
+        if (!html.startsWith("<html>") && !html.startsWith("<body>")) {
+            wrapHTML = "<div id='" + getWrapperId() + "'>" + html + "</div>";
+        }
+        Document doc = Jsoup.parseBodyFragment(wrapHTML);
+        doc.outputSettings().indentAmount(0).prettyPrint(false)
+                .syntax(Document.OutputSettings.Syntax.html);
         return doc;
     }
 
@@ -136,7 +142,7 @@ public final class ArticleUtil {
         if (wrapper != null) {
             return wrapper.childNodes();
         }
-        return null;
+        return Lists.newArrayList(element);
     }
 
     /**
@@ -147,7 +153,7 @@ public final class ArticleUtil {
         if (wrapper != null) {
             return wrapper.children();
         }
-        return null;
+        return Lists.newArrayList(element);
     }
 
     // parse html string into element

--- a/src/main/java/org/zanata/mt/util/ArticleUtil.java
+++ b/src/main/java/org/zanata/mt/util/ArticleUtil.java
@@ -8,15 +8,10 @@ import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
-import org.jsoup.parser.Parser;
 import org.jsoup.parser.Tag;
-import org.jsoup.safety.Whitelist;
 import org.zanata.mt.model.TranslatableHTMLNode;
 
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,7 +132,7 @@ public final class ArticleUtil {
     /**
      * Unwrap a wrapped element inside ZANATA-MT wrapper.
      */
-    public static @Nullable List<Node> unwrapAsNodes(@NotNull Element element) {
+    public static List<Node> unwrapAsNodes(@NotNull Element element) {
         Element wrapper = element.select("#" + getWrapperId()).first();
         if (wrapper != null) {
             return wrapper.childNodes();
@@ -148,7 +143,7 @@ public final class ArticleUtil {
     /**
      * Unwrap a wrapped element inside ZANATA-MT wrapper.
      */
-    public static @Nullable List<Element> unwrapAsElements(@NotNull Element element) {
+    public static List<Element> unwrapAsElements(@NotNull Element element) {
         Element wrapper = element.select("#" + getWrapperId()).first();
         if (wrapper != null) {
             return wrapper.children();

--- a/src/test/java/org/zanata/mt/util/ArticleUtilTest.java
+++ b/src/test/java/org/zanata/mt/util/ArticleUtilTest.java
@@ -1,8 +1,12 @@
 package org.zanata.mt.util;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.jsoup.Jsoup;
 import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
+import org.jsoup.parser.Parser;
 import org.jsoup.parser.Tag;
 import org.junit.Test;
 import org.zanata.mt.model.TranslatableHTMLNode;
@@ -10,6 +14,7 @@ import org.zanata.mt.model.TranslatableHTMLNode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,15 +43,15 @@ public class ArticleUtilTest {
 
     @Test
     public void wrapUnWrapHTML() {
-        assertWrapAndUnwrapHTML("<html><body>test</body></html>");
-        assertWrapAndUnwrapHTML("<body>test</body>");
+        assertWrapAndUnwrapHTML("<html><head></head><body>test</body></html>");
         assertWrapAndUnwrapHTML("<div>test</div>");
+        assertWrapAndUnwrapHTML("<div><br>test</div>");
         assertWrapAndUnwrapHTML("test");
     }
 
     @Test
     public void asElement() {
-        String html = "<html><body>test</body></html>";
+        String html = "<html><head></head><body>test</body></html>";
         Node node = ArticleUtil.asElement(html);
         assertThat(node).isNotNull().extracting(Node::outerHtml)
                 .contains(html);
@@ -54,9 +59,6 @@ public class ArticleUtilTest {
 
     private void assertWrapAndUnwrapHTML(String html) {
         Element wrappedElement = ArticleUtil.wrapHTML(html);
-        assertThat(wrappedElement.outerHtml()).isNotEqualTo(html);
-        assertThat(wrappedElement.outerHtml().length())
-                .isGreaterThan(html.length());
 
         List<Node> unwrappedNodes = ArticleUtil.unwrapAsNodes(wrappedElement);
         assertThat(unwrappedNodes).isNotEmpty();
@@ -64,9 +66,7 @@ public class ArticleUtilTest {
         String unwrappedHTML =
                 unwrappedNodes.stream().map(node -> node.outerHtml())
                         .collect(Collectors.joining());
-
-        assertThat(unwrappedHTML.replaceAll("\n", "")
-                .replaceAll(" ", "")).isEqualTo(html);
+        assertThat(unwrappedHTML).isEqualTo(html);
     }
 
     @Test


### PR DESCRIPTION
Fix html linebreak issue

e.g request
``` 
{"contents":[{"value":"<p>The client connecting to Red Hat Gluster Storage can have any of the following operating systems:<br \/>\n- Red Hat Enterprise Linux 6.5 or higher<br \/>\n- Fedora 22 or higher<br \/>\n- CentOS 6.x or higher<\/p>\n","type":"text\/html","metadata":"title"}],"localeCode":"en-us","url":"http:\/\/localhost\/articles\/2985486"}
``` 
Response include extra <br> tag at the end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-mt/19)
<!-- Reviewable:end -->
