### PR TITLE
ZNTAMT-8 alternative way to provide google credential

### DIFF
--- a/server/src/main/java/org/zanata/mt/backend/google/GoogleCredential.java
+++ b/server/src/main/java/org/zanata/mt/backend/google/GoogleCredential.java
@@ -84,10 +84,6 @@ public class GoogleCredential {
 
     private static void writeGoogleADCFile(File googleADCFile,
             String googleADCContent) {
-        Preconditions.checkArgument(
-                googleADCFile.exists() && googleADCFile.isFile()
-                        && googleADCFile.canWrite(),
-                "%s is not a valid file path", googleADCFile);
 
         boolean mkdirs = googleADCFile.getParentFile().mkdirs();
         log.info("{} parent dir created: {}", googleADCFile, mkdirs);

--- a/server/src/test/java/org/zanata/mt/backend/google/GoogleCredentialTest.java
+++ b/server/src/test/java/org/zanata/mt/backend/google/GoogleCredentialTest.java
@@ -25,11 +25,14 @@ public class GoogleCredentialTest {
     }
 
     @Test
-    public void googleCredentialFileMustExistIfGivingCredentialContent() {
-        assertThatThrownBy(() -> GoogleCredential.from("/Non/exist/file/path",
-                CREDENTIAL_FILE_CONTENT))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("/Non/exist/file/path is not a valid file path");
+    public void canWriteGoogleCredentialFileIfGivingCredentialContent()
+            throws IOException {
+        File folder = temporaryFolder.newFolder();
+        File destFile = new File(folder, "some/new/file.json");
+        GoogleCredential.from(destFile.getAbsolutePath(),
+                CREDENTIAL_FILE_CONTENT);
+        assertThat(destFile.exists()).isTrue();
+        assertThat(destFile).hasContent(CREDENTIAL_FILE_CONTENT);
     }
 
     @Test

--- a/server/src/test/java/org/zanata/mt/backend/google/GoogleCredentialTest.java
+++ b/server/src/test/java/org/zanata/mt/backend/google/GoogleCredentialTest.java
@@ -29,10 +29,11 @@ public class GoogleCredentialTest {
             throws IOException {
         File folder = temporaryFolder.newFolder();
         File destFile = new File(folder, "some/new/file.json");
-        GoogleCredential.from(destFile.getAbsolutePath(),
-                CREDENTIAL_FILE_CONTENT);
-        assertThat(destFile.exists()).isTrue();
-        assertThat(destFile).hasContent(CREDENTIAL_FILE_CONTENT);
+        GoogleCredential credential =
+                GoogleCredential.from(destFile.getAbsolutePath(),
+                        CREDENTIAL_FILE_CONTENT);
+        assertThat(credential.exists()).isTrue();
+        assertThat(credential.getCredentialsFile()).hasContent(CREDENTIAL_FILE_CONTENT);
     }
 
     @Test


### PR DESCRIPTION
In Openshift environment, this will make it possible to just create the file on the fly (e.g. not requiring the file's existence as prerequisite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-mt/31)
<!-- Reviewable:end -->
