### PR TITLE
fix(ZNTA-2270): Use JsonSluperClassic instead of JsonSluper

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,9 +28,9 @@
 public static final String PROJ_URL = 'https://github.com/zanata/zanata-mt'
 
 @Field
-public static final String PIPELINE_LIBRARY_BRANCH = 'v0.3.0'
+public static final String PIPELINE_LIBRARY_BRANCH = 'v0.3.1'
 
-@Library('github.com/zanata/zanata-pipeline-library@v0.3.0')
+@Library('github.com/zanata/zanata-pipeline-library@v0.3.1')
 import org.zanata.jenkins.Notifier
 import org.zanata.jenkins.PullRequests
 import org.zanata.jenkins.ScmGit

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,9 @@ import org.zanata.jenkins.ScmGit
 import static org.zanata.jenkins.Reporting.codecov
 import static org.zanata.jenkins.StackTraces.getStackTrace
 
-import groovy.json.JsonSlurper
+// JsonSluper does not work
+// https://stackoverflow.com/questions/37864542/jenkins-pipeline-notserializableexception-groovy-json-internal-lazymap/38439681#38439681
+import groovy.json.JsonSlurperClassic
 import groovy.transform.Field
 
 milestone 0
@@ -495,6 +497,6 @@ void processTestResults() {
 
 @NonCPS
 def jsonParse(def json) {
-  new JsonSlurper().parseText(json)
+  new JsonSlurperClassic().parseText(json)
 }
 


### PR DESCRIPTION
Groovy 2.3 (note: Jenkins 2.7.1 uses Groovy 2.4.7) JsonSlurper returns LazyMap instead of HashMap. This makes new implementation of JsonSlurper not thread safe and not serializable.

https://stackoverflow.com/questions/37864542/jenkins-pipeline-notserializableexception-groovy-json-internal-lazymap/38439681#38439681

Note that this change is not compatible with Jenkins 1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-mt/39)
<!-- Reviewable:end -->
