### PR TITLE
Update JaCoCo (filters out Kotlin codegen)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <docker-maven-plugin.version>0.26.1</docker-maven-plugin.version>
     <icu4j.version>58.2</icu4j.version>
     <postgresql.version>9.4.1212</postgresql.version>
-    <jacoco-maven-plugin.version>0.8.1</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
     <enunciate.version>2.8.0</enunciate.version>
     <urlrewritefilter.version>4.0.4</urlrewritefilter.version>
     <cdi-api.version>1.2</cdi-api.version>


### PR DESCRIPTION
https://github.com/jacoco/jacoco/releases/tag/v0.8.2